### PR TITLE
fix stream position bug

### DIFF
--- a/Cloud Computing/Azure Functions/Session 2 - Hands On/Azure Functions HOL (C#).md
+++ b/Cloud Computing/Azure Functions/Session 2 - Hands On/Azure Functions HOL (C#).md
@@ -149,7 +149,9 @@ Once you have created an Azure Function App, you can add Azure Functions to it. 
 	    log.Info("Adult Score: " + result.adult.adultScore.ToString());
 	    log.Info("Is Racy: " + result.adult.isRacyContent.ToString());
 	    log.Info("Racy Score: " + result.adult.racyScore.ToString());
-	
+	    
+	    // Reset stream to the beginning 
+	    myBlob.Seek(0, SeekOrigin.Begin);
 	    if (result.adult.isAdultContent || result.adult.isRacyContent)
 	    {
 	        // Copy blob to the "rejected" container


### PR DESCRIPTION
The myBlob stream is read multiple times in the function. The stream's position needs reset to the beginning before reading from it; otherwise, it will write 0 bytes to the "rejected" or "accepted" storage container.