### PR TITLE
Azure Function HOL (JS) npm init step missing

### DIFF
--- a/Cloud Computing/Azure Functions/Session 2 - Hands On/Azure Functions HOL (JavaScript).html
+++ b/Cloud Computing/Azure Functions/Session 2 - Hands On/Azure Functions HOL (JavaScript).html
@@ -701,6 +701,11 @@ vertical-align:1px;
 </code></pre>
 </li>
 <li>
+<p>Execute the following command to create package.json file:</p>
+<pre><code>npm init --force -y
+</code></pre>
+</li>
+<li>
 <p>Execute the following command to install the Node Package Manager (NPM):</p>
 <pre><code>npm install
 </code></pre>

--- a/Cloud Computing/Azure Functions/Session 2 - Hands On/Azure Functions HOL (JavaScript).md
+++ b/Cloud Computing/Azure Functions/Session 2 - Hands On/Azure Functions HOL (JavaScript).md
@@ -257,7 +257,11 @@ Once you have created an Azure Function App, you can add Azure Functions to it. 
 	```
 	cd BlobImageAnalyis
 	```
+1. Execute the following command to create package.json file:
 
+	```
+	npm init --force -y
+	```
 1. Execute the following command to install the Node Package Manager (NPM):
 
 	```


### PR DESCRIPTION
I was trying the hands-on-lab of Azure Functions and found out that one step is missing in the process. The package.json file must be created before installing modules. To create a package.json file I have used `npm init --force -y` command. `--force -y` is used to skip the questions and let npm decide the name and description of package. 