### PR TITLE
Updated URI for Cognitive Services. Uris containing api.projectoxford…

### DIFF
--- a/Cloud Computing/Azure Functions/Session 2 - Hands On/Azure Functions HOL (C#).html
+++ b/Cloud Computing/Azure Functions/Session 2 - Hands On/Azure Functions HOL (C#).html
@@ -621,7 +621,7 @@ vertical-align:1px;
     <span class="pl-en">HttpContent</span> <span class="pl-en">payload</span> = <span class="pl-k">new</span> <span class="pl-en">ByteArrayContent</span>(<span class="pl-en">bytes</span>);
     payload.Headers.ContentType = <span class="pl-k">new</span> <span class="pl-en">MediaTypeWithQualityHeaderValue</span>(<span class="pl-s"><span class="pl-pds">"</span>application/octet-stream<span class="pl-pds">"</span></span>);
     
-    <span class="pl-k">var</span> <span class="pl-en">results </span>= <span class="pl-k">await</span> client.PostAsync(<span class="pl-s"><span class="pl-pds">"</span>https://api.projectoxford.ai/vision/v1.0/analyze?visualFeatures=Adult<span class="pl-pds">"</span></span>, payload);
+    <span class="pl-k">var</span> <span class="pl-en">results </span>= <span class="pl-k">await</span> client.PostAsync(<span class="pl-s"><span class="pl-pds">"</span>https://westus.api.cognitive.microsoft.com/vision/v1.0/analyze?visualFeatures=Adult<span class="pl-pds">"</span></span>, payload);
     <span class="pl-k">var</span> <span class="pl-en">result </span>= <span class="pl-k">await</span> results.Content.ReadAsAsync&lt;ImageAnalysisInfo&gt;();
     <span class="pl-k">return</span> result;
 }

--- a/Cloud Computing/Azure Functions/Session 2 - Hands On/Azure Functions HOL (C#).md
+++ b/Cloud Computing/Azure Functions/Session 2 - Hands On/Azure Functions HOL (C#).md
@@ -172,7 +172,7 @@ Once you have created an Azure Function App, you can add Azure Functions to it. 
 	    HttpContent payload = new ByteArrayContent(bytes);
 	    payload.Headers.ContentType = new MediaTypeWithQualityHeaderValue("application/octet-stream");
 	    
-	    var results = await client.PostAsync("https://api.projectoxford.ai/vision/v1.0/analyze?visualFeatures=Adult", payload);
+	    var results = await client.PostAsync("https://westus.api.cognitive.microsoft.com/vision/v1.0/analyze?visualFeatures=Adult", payload);
 	    var result = await results.Content.ReadAsAsync<ImageAnalysisInfo>();
 	    return result;
 	}

--- a/Cloud Computing/Azure Functions/Session 2 - Hands On/Azure Functions HOL (JavaScript).html
+++ b/Cloud Computing/Azure Functions/Session 2 - Hands On/Azure Functions HOL (JavaScript).html
@@ -593,7 +593,7 @@ vertical-align:1px;
 
 <span class="pl-k">function</span> <span class="pl-en">getAnalysisOptions</span>(<span class="pl-smi">image</span>, <span class="pl-smi">subscriptionKey</span>) {
     <span class="pl-k">return</span>  {
-        uri<span class="pl-k">:</span> <span class="pl-s"><span class="pl-pds">"</span>https://api.projectoxford.ai/vision/v1.0/analyze?visualFeatures=Adult<span class="pl-pds">"</span></span>,
+        uri<span class="pl-k">:</span> <span class="pl-s"><span class="pl-pds">"</span>https://westus.api.cognitive.microsoft.com/vision/v1.0/analyze?visualFeatures=Adult<span class="pl-pds">"</span></span>,
         method<span class="pl-k">:</span> <span class="pl-s"><span class="pl-pds">'</span>POST<span class="pl-pds">'</span></span>,
         body<span class="pl-k">:</span> image,
         headers<span class="pl-k">:</span> {

--- a/Cloud Computing/Azure Functions/Session 2 - Hands On/Azure Functions HOL (JavaScript).md
+++ b/Cloud Computing/Azure Functions/Session 2 - Hands On/Azure Functions HOL (JavaScript).md
@@ -144,7 +144,7 @@ Once you have created an Azure Function App, you can add Azure Functions to it. 
 
 	function getAnalysisOptions(image, subscriptionKey) {
 	    return  {
-	        uri: "https://api.projectoxford.ai/vision/v1.0/analyze?visualFeatures=Adult",
+	        uri: "https://westus.api.cognitive.microsoft.com/vision/v1.0/analyze?visualFeatures=Adult",
 	        method: 'POST',
 	        body: image,
 	        headers: {


### PR DESCRIPTION
Hi, I just played through the Cloud Computing/Azure Functions HOL and noticed that the URLs for Cognitive Services are still the old one. 

Uris containing api.projectoxford.ai will be retired per April 15, 2017