### PR TITLE
Fix Cordava and Xamarin document links

### DIFF
--- a/Mobile Development/README.md
+++ b/Mobile Development/README.md
@@ -2,8 +2,8 @@
 
 Explore the sub-folders to find community-ready presentation materials on the following topics:
 
-- [Xamarin](Devops/README.md)
-- [Cordova](Cordova/README.md)
+- [Xamarin](Xamarin)
+- [Cordova](Cordova)
 
 
 **Introduction**


### PR DESCRIPTION
Fixed the link (Xamarin and Cordva) at the top of the next page.
https://github.com/Microsoft/TechnicalCommunityContent/tree/master/Mobile%20Development